### PR TITLE
fix: use artifacts from GitHub, fixes #2

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -4,7 +4,7 @@ setup() {
   export TESTDIR=~/tmp/test-python2
   mkdir -p $TESTDIR
   export PROJNAME=test-python2
-  export DDEV_NON_INTERACTIVE=true
+  export DDEV_NONINTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
@@ -32,6 +32,7 @@ teardown() {
   health_checks
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )

--- a/web-build/Dockerfile.python2
+++ b/web-build/Dockerfile.python2
@@ -1,14 +1,9 @@
 #ddev-generated
 # Adapted from https://www.fadedbee.com/2024/01/18/installing-python2-on-debian-12-bookworm/
 ARG TARGETPLATFORM
-RUN debian_shapshot_url="https://snapshot.debian.org/archive/debian/20240830T023056Z/pool/main" && \
-    mkdir -p /tmp/python2 && \
-    wget -O /tmp/python2/libffi7.deb $debian_shapshot_url/libf/libffi/libffi7_3.3-6_${TARGETPLATFORM##linux/}.deb && \
-    wget -O /tmp/python2/libssl1.1.deb $debian_shapshot_url/o/openssl/libssl1.1_1.1.1w-0+deb11u1_${TARGETPLATFORM##linux/}.deb && \
-    wget -O /tmp/python2/libpython2.7-minimal.deb $debian_shapshot_url/p/python2.7/libpython2.7-minimal_2.7.18-8+deb11u1_${TARGETPLATFORM##linux/}.deb && \
-    wget -O /tmp/python2/libpython2.7-stdlib.deb $debian_shapshot_url/p/python2.7/libpython2.7-stdlib_2.7.18-8+deb11u1_${TARGETPLATFORM##linux/}.deb && \
-    wget -O /tmp/python2/python2.7-minimal.deb $debian_shapshot_url/p/python2.7/python2.7-minimal_2.7.18-8+deb11u1_${TARGETPLATFORM##linux/}.deb && \
-    wget -O /tmp/python2/python2.7.deb $debian_shapshot_url/p/python2.7/python2.7_2.7.18-8+deb11u1_${TARGETPLATFORM##linux/}.deb && \
+RUN mkdir -p /tmp/python2 && \
+    wget -O /tmp/python2/python2.7.tar.gz https://github.com/stasadev/ddev-python2/releases/download/v1.0.0/python2.7_${TARGETPLATFORM##linux/}.tar.gz && \
+    tar -xzf /tmp/python2/python2.7.tar.gz -C /tmp/python2 && \
     dpkg -i /tmp/python2/*.deb && \
     rm -rf /tmp/python2 && \
     ln -s /usr/bin/python2.7 /usr/local/bin/python


### PR DESCRIPTION
## The Issue

- #2

## How This PR Solves The Issue

The link https://snapshot.debian.org/archive/debian/20240830T023056Z/pool/main doesn't respond, and other snapshot pages seem unreliable.

I downloaded all packages for all architectures from https://ftp.debian.org/debian/pool/main/ and put them here https://github.com/stasadev/ddev-python2/releases/tag/v1.0.0