### PR TITLE
Replace `ddev get` with `ddev add-on get` in tests

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -26,8 +26,8 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
@@ -36,8 +36,8 @@ teardown() {
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get stasadev/ddev-python2 with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get stasadev/ddev-python2
+  echo "# ddev add-on get stasadev/ddev-python2 with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get stasadev/ddev-python2
   ddev restart >/dev/null
   health_checks
 }


### PR DESCRIPTION
## The Issue

This is a follow-up for:

- #1

## How This PR Solves The Issue

Replaces `ddev get` with `ddev add-on get` in tests.
