### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ It is only needed if your `npm` setup requires Python 2 to build dependencies.
 For DDEV v1.23.5 or above run:
 
 ```bash
-ddev add-on get ddev/ddev-python2
+ddev add-on get stasadev/ddev-python2
 ddev restart
 ```
 
 For earlier versions of DDEV run:
 
 ```bash
-ddev get ddev/ddev-python2
+ddev get stasadev/ddev-python2
 ddev restart
 ```
 


### PR DESCRIPTION
Adjust ddev addon command

## The Issue

The original command listed in the README.md file `ddev add-on get ddev/ddev-python2` results in a 404.

## How This PR Solves The Issue

Updates the README to provide the correct command

## Manual Testing Instructions

Simply run the newly provided command:

```bash
ddev add-on get stasadev/ddev-python2
ddev restart
```

## Automated Testing Overview

N/A

## Release/Deployment Notes

N/A
