### PR TITLE
chore(*): run update-checker.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Exclude files from releases/tarballs
+tests/ export-ignore
+.github/ export-ignore
+.gitattributes export-ignore

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,21 @@
 ## The Issue
 
-- #<issue number>
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
 
 <!-- Provide a brief description of the issue. -->
 
 ## How This PR Solves The Issue
 
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
 ## Manual Testing Instructions
 
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
 ```bash
-ddev add-on get https://github.com/<user>/<repo>/tarball/<branch>
+ddev add-on get https://github.com/stasadev/ddev-python2/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
+ddev exec python -V
 ```
 
 ## Automated Testing Overview

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,15 @@
 name: tests
 on:
   pull_request:
+    paths-ignore:
+      - "**.md"
   push:
     branches: [ main ]
+    paths-ignore:
+      - "**.md"
 
   schedule:
-  - cron: '25 08 * * *'
+    - cron: '25 08 * * *'
 
   workflow_dispatch:
     inputs:

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ After installation, make sure to commit the `.ddev` directory to version control
 
 ## Usage
 
-After installation, you can run Python 2:
-
-- `python2.7` (installed at `/usr/bin/python2.7`)
-- `python` (symlink to `python2.7` installed at `/usr/local/bin/python`)
+| Command | Description |
+| ------- | ----------- |
+| `ddev exec python2.7` | Run Python 2.7.18 inside the `web` container<br>Installed at `/usr/bin/python2.7` |
+| `ddev exec python` | Run Python 2.7.18 inside the `web` container<br>Symlink to `/usr/bin/python2.7` installed at `/usr/local/bin/python` |
 
 This add-on also installs `build-essential`, which is normally required for `npm` build, see [config.python2.yaml](./config.python2.yaml). Remove or replace the contents of this file if you only need Python 2.
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,12 @@ It is only needed if your `npm` setup requires Python 2 to build dependencies.
 
 ## Installation
 
-For DDEV v1.23.5 or above run:
-
 ```bash
 ddev add-on get stasadev/ddev-python2
 ddev restart
 ```
 
-For earlier versions of DDEV run:
-
-```bash
-ddev get stasadev/ddev-python2
-ddev restart
-```
+After installation, make sure to commit the `.ddev` directory to version control.
 
 ## Usage
 
@@ -36,7 +29,7 @@ After installation, you can run Python 2:
 - `python2.7` (installed at `/usr/bin/python2.7`)
 - `python` (symlink to `python2.7` installed at `/usr/local/bin/python`)
 
-This add-on also adds packages that are normally required for `npm` build, see [config.python2.yaml](./config.python2.yaml). Remove or replace the contents of this file if you only need Python 2.
+This add-on also installs `build-essential`, which is normally required for `npm` build, see [config.python2.yaml](./config.python2.yaml). Remove or replace the contents of this file if you only need Python 2.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ After installation, make sure to commit the `.ddev` directory to version control
 
 | Command | Description |
 | ------- | ----------- |
-| `ddev exec python2.7` | Run Python 2.7.18 inside the `web` container<br>Installed at `/usr/bin/python2.7` |
-| `ddev exec python` | Run Python 2.7.18 inside the `web` container<br>Symlink to `/usr/bin/python2.7` installed at `/usr/local/bin/python` |
+| `ddev exec python2.7` | Run Python 2.7.18 inside the `web` container.<br>Installed at `/usr/bin/python2.7` |
+| `ddev exec python` | Run Python 2.7.18 inside the `web` container.<br>Symlink at `/usr/local/bin/python` |
 
-This add-on also installs `build-essential`, which is normally required for `npm` build, see [config.python2.yaml](./config.python2.yaml). Remove or replace the contents of this file if you only need Python 2.
+This add-on also installs the `build-essential` package, which is usually required for the `npm build`, see [config.python2.yaml](./config.python2.yaml). Remove or replace the contents of this file if you only need Python 2.
 
 ## Credits
 

--- a/install.yaml
+++ b/install.yaml
@@ -1,13 +1,7 @@
 name: python2
 
-# list of files and directories listed that are copied into project .ddev directory
 project_files:
   - config.python2.yaml
   - web-build/Dockerfile.python2
 
-pre_install_actions:
-  # Ensure we're on DDEV 1.23+ which uses Debian 12+ with Python3,
-  # Python2 is available by default in previous versions of Debian.
-  - |
-    #ddev-description:Checking DDEV version
-    (ddev debug capabilities | grep corepack >/dev/null) || (echo "This addon should only be installed in DDEV v1.23+ since you already have Python2 in yours $(ddev --version)" && false)
+ddev_version_constraint: '>= v1.23.5'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -26,8 +26,8 @@ setup() {
 
   export DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")/.." >/dev/null 2>&1 && pwd)"
   export PROJNAME="test-$(basename "${GITHUB_REPO}")"
-  mkdir -p ~/tmp
-  export TESTDIR=$(mktemp -d ~/tmp/${PROJNAME}.XXXXXX)
+  mkdir -p "${HOME}/tmp"
+  export TESTDIR="$(mktemp -d "${HOME}/tmp/${PROJNAME}.XXXXXX")"
   export DDEV_NONINTERACTIVE=true
   export DDEV_NO_INSTRUMENTATION=true
   ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1 || true
@@ -50,8 +50,14 @@ health_checks() {
 
 teardown() {
   set -eu -o pipefail
-  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
-  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+  ddev delete -Oy "${PROJNAME}" >/dev/null 2>&1
+  # Persist TESTDIR if running inside GitHub Actions. Useful for uploading test result artifacts
+  # See example at https://github.com/ddev/github-action-add-on-test#preserving-artifacts
+  if [ -n "${GITHUB_ENV:-}" ]; then
+    [ -e "${GITHUB_ENV:-}" ] && echo "TESTDIR=${HOME}/tmp/${PROJNAME}" >> "${GITHUB_ENV}"
+  else
+    [ "${TESTDIR}" != "" ] && rm -rf "${TESTDIR}"
+  fi
 }
 
 @test "install from directory" {


### PR DESCRIPTION
## The Issue

Run:

```bash
curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
```

## How This PR Solves The Issue

- Removes call to `ddev debug capabilities`, which is going to be removed.
- Adds v1.23.5 version constraint - it's not really needed here to have any constraint, but doing this for `ddev add-on get` in README.md
- Applies other suggestions

## Manual Testing Instructions

```
ddev add-on get https://github.com/stasadev/ddev-python2/tarball/refs/pull/11/head
ddev restart
ddev exec python -V
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
