### PR TITLE
feat: add compatibility with Debian Trixie

### DIFF
--- a/config.python2.yaml
+++ b/config.python2.yaml
@@ -1,2 +1,2 @@
 #ddev-generated
-webimage_extra_packages: [build-essential, mime-support]
+webimage_extra_packages: [build-essential]


### PR DESCRIPTION
## The Issue

Using:

- https://github.com/ddev/ddev/pull/7649

```
$ ddev add-on get stasadev/ddev-python2
$ ddev restart
...
4.200 E: Package 'mime-support' has no installation candidate
...
```

## How This PR Solves The Issue

`mime-support` is a dependency for `python2` and it's been removed from Debian Trixie.
It was already a transitional package for `media-types`: https://packages.debian.org/bookworm/mime-support

I downloaded `mime-support` and its dependency `mailcap` from:

- https://snapshot.debian.org/archive/debian/20240830T023056Z/pool/main/m/mime-support/
- https://snapshot.debian.org/archive/debian/20240830T023056Z/pool/main/m/mailcap/

Then updated the assets here to include these packages in the archives: https://github.com/stasadev/ddev-python2/releases/tag/v1.0.0

So the only required change is to remove `mime-support` from `.ddev/config.python2.yaml`.

People using DDEV v1.25.0 only need to do one of the following:

- Remove `mime-support` manually  
- Or run `ddev add-on get stasadev/ddev-python2`, which will do the same

It will continue to work with DDEV v1.24.x as well.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/stasadev/ddev-python2/tarball/refs/pull/12/head
ddev restart
ddev exec python -V
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
