### PR TITLE
fix: install libnsl2 with deps

### DIFF
--- a/web-build/Dockerfile.python2
+++ b/web-build/Dockerfile.python2
@@ -1,9 +1,11 @@
 #ddev-generated
-# Adapted from https://www.fadedbee.com/2024/01/18/installing-python2-on-debian-12-bookworm/
+# Adapted from https://web.archive.org/web/20250223192706/https://www.fadedbee.com/2024/01/18/installing-python2-on-debian-12-bookworm/
 ARG TARGETARCH
 RUN mkdir -p /tmp/python2 && \
-    wget -O /tmp/python2/python2.7.tar.gz https://github.com/stasadev/ddev-python2/releases/download/v1.0.0/python2.7_${TARGETARCH}.tar.gz && \
+    wget -O /tmp/python2/python2.7.tar.gz https://github.com/stasadev/ddev-python2/releases/download/v1.0.1/python2.7_${TARGETARCH}.tar.gz && \
     tar -xzf /tmp/python2/python2.7.tar.gz -C /tmp/python2 && \
+    source /etc/os-release && \
+    if [ "$VERSION_CODENAME" = "bookworm" ]; then rm -f /tmp/python2/libnsl2*.deb /tmp/python2/libtirpc3t64*.deb; fi && \
     dpkg -i /tmp/python2/*.deb && \
     rm -rf /tmp/python2 && \
     ln -s /usr/bin/python2.7 /usr/local/bin/python


### PR DESCRIPTION
## The Issue

https://github.com/stasadev/ddev-python2/actions/runs/20092657099/job/57643461417#step:2:1964

```
#   #20 0.877  libpython2.7-stdlib:amd64 depends on libnsl2 (>= 1.0); however:
#   #20 0.877   Package libnsl2 is not installed.
```

## How This PR Solves The Issue

Fixes it by updating artifacts https://github.com/stasadev/ddev-python2/releases/tag/v1.0.1 with more dependencies.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/stasadev/ddev-python2/tarball/refs/pull/13/head
ddev restart
ddev exec python -V
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
