### PR TITLE
feat: install from python:2.7-slim, version constraint v1.24.10

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@
 ddev add-on get https://github.com/stasadev/ddev-python2/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ddev exec python --version
+ddev exec pip --version
 ```
 
 ## Automated Testing Overview

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 ```bash
 ddev add-on get https://github.com/stasadev/ddev-python2/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
-ddev exec python -V
+ddev exec python --version
 ```
 
 ## Automated Testing Overview

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ After installation, make sure to commit the `.ddev` directory to version control
 
 | Command | Description |
 | ------- | ----------- |
-| `ddev exec python2.7` | Run Python 2.7.18 inside the `web` container.<br>Installed at `/usr/bin/python2.7` |
-| `ddev exec python` | Run Python 2.7.18 inside the `web` container.<br>Symlink at `/usr/local/bin/python` |
+| `ddev exec python` | Run Python 2.7.18 inside the `web` container.<br>Installed at `/usr/local/bin/python` |
+| `ddev exec pip` | Run pip 20.0.2 inside the `web` container.<br>Installed at `/usr/local/bin/pip` |
 
 This add-on also installs the `build-essential` package, which is usually required for the `npm build`, see [config.python2.yaml](./config.python2.yaml). Remove or replace the contents of this file if you only need Python 2.
 

--- a/docker-compose.python2.yaml
+++ b/docker-compose.python2.yaml
@@ -1,0 +1,7 @@
+#ddev-generated
+services:
+  # This service is only used to pull the Docker image for offline use.
+  python2:
+    image: python:2.7-slim-${DDEV_SITENAME}-built
+    profiles:
+      - python2

--- a/install.yaml
+++ b/install.yaml
@@ -2,6 +2,7 @@ name: python2
 
 project_files:
   - config.python2.yaml
+  - docker-compose.python2.yaml
   - web-build/Dockerfile.python2
 
-ddev_version_constraint: '>= v1.23.5'
+ddev_version_constraint: '>= v1.24.10'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -43,6 +43,10 @@ health_checks() {
   assert_success
   assert_output "Python 2.7.18"
 
+  run ddev exec python2 --version
+  assert_success
+  assert_output "Python 2.7.18"
+
   run ddev exec python2.7 --version
   assert_success
   assert_output "Python 2.7.18"
@@ -51,11 +55,19 @@ health_checks() {
   assert_success
   assert_output "pip 20.0.2 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)"
 
-  run python -c "import hashlib; print('MD5:', hashlib.md5('test').hexdigest())"
+  run ddev exec pip2 --version
+  assert_success
+  assert_output "pip 20.0.2 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)"
+
+  run ddev exec pip2.7 --version
+  assert_success
+  assert_output "pip 20.0.2 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)"
+
+  run ddev exec python -c "import hashlib; print('MD5:', hashlib.md5('test').hexdigest())"
   assert_success
   assert_output "('MD5:', '098f6bcd4621d373cade4e832627b4f6')"
 
-  run python -c "import ssl; print('SSL:', ssl.OPENSSL_VERSION)"
+  run ddev exec python -c "import ssl; print('SSL:', ssl.OPENSSL_VERSION)"
   assert_success
   assert_output "('SSL:', 'OpenSSL 1.1.1d  10 Sep 2019')"
 }

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -39,13 +39,25 @@ setup() {
 }
 
 health_checks() {
-  run ddev exec python -V
+  run ddev exec python --version
   assert_success
   assert_output "Python 2.7.18"
 
-  run ddev exec python2.7 -V
+  run ddev exec python2.7 --version
   assert_success
   assert_output "Python 2.7.18"
+
+  run ddev exec pip --version
+  assert_success
+  assert_output "pip 20.0.2 from /usr/local/lib/python2.7/site-packages/pip (python 2.7)"
+
+  run python -c "import hashlib; print('MD5:', hashlib.md5('test').hexdigest())"
+  assert_success
+  assert_output "('MD5:', '098f6bcd4621d373cade4e832627b4f6')"
+
+  run python -c "import ssl; print('SSL:', ssl.OPENSSL_VERSION)"
+  assert_success
+  assert_output "('SSL:', 'OpenSSL 1.1.1d  10 Sep 2019')"
 }
 
 teardown() {

--- a/web-build/Dockerfile.python2
+++ b/web-build/Dockerfile.python2
@@ -1,11 +1,17 @@
 #ddev-generated
-# Adapted from https://web.archive.org/web/20250223192706/https://www.fadedbee.com/2024/01/18/installing-python2-on-debian-12-bookworm/
+COPY --from=python:2.7-slim /usr/local /usr/local
+COPY --from=python:2.7-slim /usr/lib/ /tmp/python2-libs/
 ARG TARGETARCH
-RUN mkdir -p /tmp/python2 && \
-    wget -O /tmp/python2/python2.7.tar.gz https://github.com/stasadev/ddev-python2/releases/download/v1.0.1/python2.7_${TARGETARCH}.tar.gz && \
-    tar -xzf /tmp/python2/python2.7.tar.gz -C /tmp/python2 && \
-    source /etc/os-release && \
-    if [ "$VERSION_CODENAME" = "bookworm" ]; then rm -f /tmp/python2/libnsl2*.deb /tmp/python2/libtirpc3t64*.deb; fi && \
-    dpkg -i /tmp/python2/*.deb && \
-    rm -rf /tmp/python2 && \
-    ln -s /usr/bin/python2.7 /usr/local/bin/python
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+        LIB_ARCH="x86_64-linux-gnu"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+        LIB_ARCH="aarch64-linux-gnu"; \
+    else \
+        echo "Unsupported architecture: $TARGETARCH"; exit 1; \
+    fi && \
+    echo "Detected architecture: $TARGETARCH ($LIB_ARCH)" && \
+    mkdir -p /usr/lib/$LIB_ARCH && \
+    cp /tmp/python2-libs/*/libssl.so.1.1 /usr/lib/$LIB_ARCH/ && \
+    cp /tmp/python2-libs/*/libcrypto.so.1.1 /usr/lib/$LIB_ARCH/ && \
+    rm -rf /tmp/python2-libs && \
+    ldconfig

--- a/web-build/Dockerfile.python2
+++ b/web-build/Dockerfile.python2
@@ -1,6 +1,6 @@
 #ddev-generated
 COPY --from=python:2.7-slim /usr/local /usr/local
-COPY --from=python:2.7-slim /usr/lib/ /tmp/python2-libs/
+COPY --from=python:2.7-slim /usr/lib /tmp/python2-libs
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
         LIB_ARCH="x86_64-linux-gnu"; \


### PR DESCRIPTION
## The Issue

Installing packages from Debian snapshots results in dependency hell:

- #12
- #13

## How This PR Solves The Issue

Uses `python:2.7-slim` to get Python 2 files.
Adds version constraint v1.24.10.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/stasadev/ddev-python2/tarball/refs/pull/14/head
ddev restart
ddev exec python --version
ddev exec pip --version
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
