### PR TITLE
chore(*): promote add-on to official

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: [ddev]
-custom: ["https://www.paypal.com/donate/?hosted_button_id=MCNCSZHC7LHSQ", "https://ddev.com/support-ddev/"]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@
 <!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
 
 ```bash
-ddev add-on get https://github.com/stasadev/ddev-python2/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
+ddev add-on get https://github.com/ddev/ddev-python2/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
 ddev restart
 ddev exec python --version
 ddev exec pip --version

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![add-on registry](https://img.shields.io/badge/DDEV-Add--on_Registry-blue)](https://addons.ddev.com)
-[![tests](https://github.com/stasadev/ddev-python2/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/stasadev/ddev-python2/actions/workflows/tests.yml?query=branch%3Amain)
-[![last commit](https://img.shields.io/github/last-commit/stasadev/ddev-python2)](https://github.com/stasadev/ddev-python2/commits)
-[![release](https://img.shields.io/github/v/release/stasadev/ddev-python2)](https://github.com/stasadev/ddev-python2/releases/latest)
+[![tests](https://github.com/ddev/ddev-python2/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-python2/actions/workflows/tests.yml?query=branch%3Amain)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-python2)](https://github.com/ddev/ddev-python2/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-python2)](https://github.com/ddev/ddev-python2/releases/latest)
 
 # DDEV Python 2
 
@@ -16,7 +16,7 @@ It is only needed if your `npm` setup requires Python 2 to build dependencies.
 ## Installation
 
 ```bash
-ddev add-on get stasadev/ddev-python2
+ddev add-on get ddev/ddev-python2
 ddev restart
 ```
 
@@ -33,4 +33,6 @@ This add-on also installs the `build-essential` package, which is usually requir
 
 ## Credits
 
-**Contributed and maintained by [@stasadev](https://github.com/stasadev)**
+**Contributed by [@stasadev](https://github.com/stasadev)**
+
+**Maintained by the [DDEV team](https://ddev.com/support-ddev/)**

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -16,7 +16,7 @@ setup() {
   set -eu -o pipefail
 
   # Override this variable for your add-on:
-  export GITHUB_REPO=stasadev/ddev-python2
+  export GITHUB_REPO=ddev/ddev-python2
 
   TEST_BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
   export BATS_LIB_PATH="${BATS_LIB_PATH}:${TEST_BREW_PREFIX}/lib:/usr/lib/bats"


### PR DESCRIPTION
## The Issue

I'm ready to promote the add-on after:

- #14

## How This PR Solves The Issue

Replaces `stasadev/ddev-python2` with `ddev/ddev-python2`.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/ddev/ddev-python2/tarball/refs/pull/15/head
ddev restart
ddev exec python --version
ddev exec pip --version
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
