### PR TITLE
fix: set permissions for /usr/local/bin

### DIFF
--- a/tests/test.bats
+++ b/tests/test.bats
@@ -76,7 +76,7 @@ health_checks() {
   if [ "${USE_CUSTOM_NODE:-}" = "true" ]; then
     run ddev exec node -v
     assert_success
-    assert_output --regexp '^v18\.\d+\.\d+$'
+    assert_output --regexp '^v18\.[0-9]+\.[0-9]+$'
   fi
 }
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -76,7 +76,7 @@ health_checks() {
   if [ "${USE_CUSTOM_NODE:-}" = "true" ]; then
     run ddev exec node -v
     assert_success
-    assert_output --regexp "^v18\\.\\d+\\.\\d+$"
+    assert_output --regexp '^v18\.\d+\.\d+$'
   fi
 }
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -36,6 +36,8 @@ setup() {
   assert_success
   run ddev start -y
   assert_success
+
+  export USE_CUSTOM_NODE=false
 }
 
 health_checks() {
@@ -70,6 +72,12 @@ health_checks() {
   run ddev exec python -c "import ssl; print('SSL:', ssl.OPENSSL_VERSION)"
   assert_success
   assert_output "('SSL:', 'OpenSSL 1.1.1d  10 Sep 2019')"
+
+  if [ "${USE_CUSTOM_NODE:-}" = "true" ]; then
+    run ddev exec node -v
+    assert_success
+    assert_output --regexp "^v18\\.\\d+\\.\\d+$"
+  fi
 }
 
 teardown() {
@@ -86,6 +94,21 @@ teardown() {
 
 @test "install from directory" {
   set -eu -o pipefail
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+  health_checks
+}
+
+@test "install with node v18" {
+  set -eu -o pipefail
+
+  export USE_CUSTOM_NODE=true
+  run ddev config --nodejs-version=v18
+  assert_success
+
   echo "# ddev add-on get ${DIR} with project ${PROJNAME} in $(pwd)" >&3
   run ddev add-on get "${DIR}"
   assert_success

--- a/web-build/Dockerfile.python2
+++ b/web-build/Dockerfile.python2
@@ -2,16 +2,20 @@
 COPY --from=python:2.7-slim /usr/local /usr/local
 COPY --from=python:2.7-slim /usr/lib /tmp/python2-libs
 ARG TARGETARCH
-RUN if [ "$TARGETARCH" = "amd64" ]; then \
-        LIB_ARCH="x86_64-linux-gnu"; \
-    elif [ "$TARGETARCH" = "arm64" ]; then \
-        LIB_ARCH="aarch64-linux-gnu"; \
-    else \
-        echo "Unsupported architecture: $TARGETARCH"; exit 1; \
-    fi && \
-    echo "Detected architecture: $TARGETARCH ($LIB_ARCH)" && \
-    mkdir -p /usr/lib/$LIB_ARCH && \
-    cp /tmp/python2-libs/*/libssl.so.1.1 /usr/lib/$LIB_ARCH/ && \
-    cp /tmp/python2-libs/*/libcrypto.so.1.1 /usr/lib/$LIB_ARCH/ && \
-    rm -rf /tmp/python2-libs && \
-    ldconfig
+RUN <<EOF
+set -eu -o pipefail
+chmod -f ugo+rwx /usr/local/bin
+if [ "$TARGETARCH" = "amd64" ]; then
+    LIB_ARCH="x86_64-linux-gnu"
+elif [ "$TARGETARCH" = "arm64" ]; then
+    LIB_ARCH="aarch64-linux-gnu"
+else
+    echo "Unsupported architecture: $TARGETARCH" >&2
+    exit 1
+fi
+mkdir -p /usr/lib/$LIB_ARCH
+cp /tmp/python2-libs/*/libssl.so.1.1 /usr/lib/$LIB_ARCH/
+cp /tmp/python2-libs/*/libcrypto.so.1.1 /usr/lib/$LIB_ARCH/
+rm -rf /tmp/python2-libs
+ldconfig
+EOF


### PR DESCRIPTION
## The Issue

Cannot change Node.js version:

```
$ ddev config --nodejs-version=v18
$ ddev start

$ ddev exec node -v
v24.12.0

$ ddev logs
...
+ n-install.sh
This script cannot write to the directory /usr/local/bin
...
```

## How This PR Solves The Issue

`COPY --from=python:2.7-slim /usr/local /usr/local` resets directory permissions, this PR adds it back, along with test coverage.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-python2/tarball/refs/pull/16/head
ddev config --nodejs-version=v18
ddev restart
ddev exec python --version
ddev exec pip --version
ddev exec node -v
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
