### PR TITLE
chore: add describe info for python2

### DIFF
--- a/docker-compose.python2.yaml
+++ b/docker-compose.python2.yaml
@@ -5,3 +5,5 @@ services:
     image: python:2.7-slim-${DDEV_SITENAME}-built
     profiles:
       - python2
+    x-ddev:
+      describe-info: "For docker pull"

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -73,6 +73,10 @@ health_checks() {
   assert_success
   assert_output "('SSL:', 'OpenSSL 1.1.1d  10 Sep 2019')"
 
+  run ddev describe
+  assert_success
+  assert_output --partial "For docker pull"
+
   if [ "${USE_CUSTOM_NODE:-}" = "true" ]; then
     run ddev exec node -v
     assert_success


### PR DESCRIPTION
## The Issue

It's a bit weird to see a stopped `python2` service in `ddev describe`.

## How This PR Solves The Issue

Adds explanation to `ddev describe`.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-python2/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev restart
ddev exec python --version
ddev exec pip --version
ddev describe
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
