### PR TITLE
fix(hardened-images): don't override permissions in /usr/local, for #16

### DIFF
--- a/web-build/Dockerfile.python2
+++ b/web-build/Dockerfile.python2
@@ -1,10 +1,11 @@
 #ddev-generated
-COPY --from=python:2.7-slim /usr/local /usr/local
+COPY --from=python:2.7-slim /usr/local /tmp/python2-local
 COPY --from=python:2.7-slim /usr/lib /tmp/python2-libs
 ARG TARGETARCH
 RUN <<EOF
 set -eu -o pipefail
-chmod -f ugo+rwx /usr/local/bin
+tar -C /tmp/python2-local -cf - . | tar -C /usr/local -xf - --no-overwrite-dir
+rm -rf /tmp/python2-local
 if [ "$TARGETARCH" = "amd64" ]; then
     LIB_ARCH="x86_64-linux-gnu"
 elif [ "$TARGETARCH" = "arm64" ]; then


### PR DESCRIPTION
## The Issue

While testing a project with hardened images + this add-on, it didn't work:

```
$ ddev logs -s web
...
+ mkcert -install
Warning: "sudo" is not available, and mkcert is not running as root. The (un)install operation might fail. ⚠
ERROR: failed to execute "tee": exit status 1

tee: /usr/local/share/ca-certificates/mkcert_development_CA_150415661751699325916863148199739114787.crt: Permission denied
...
```

The reason why it didn't work is the same as in:

- #16

We have this in the `Dockerfile` for `ddev-webserver`:

```dockerfile
RUN chmod ugo+w /etc/ssl/certs /usr/local/share/ca-certificates
```

It didn't fail with usual (not hardened) webimage is because `mkcert -install` silently added passwordless `sudo`.

## How This PR Solves The Issue

Copies `/usr/local` to a temporary directory instead, and only then copies it to the target `/usr/local` preserving the existing permissions.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-python2/tarball/refs/pull/18/head
ddev config global --use-hardened-images=true
ddev restart
ddev exec python --version
ddev exec pip --version
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
